### PR TITLE
Feature / Display Tooltip Only for the Min and Max Values per Period

### DIFF
--- a/src/js/chart.js
+++ b/src/js/chart.js
@@ -144,9 +144,21 @@ window.App.Chart.prototype.alwaysVisibleTooltipsPlugin = function() {
                     const tooltipsMaxValue = Math.max(...dataset.data);
                     const tooltipsMinValue = Math.min(...dataset.data);
 
-                    const displayTooltipsFilter = (value) => (
-                        value === tooltipsMaxValue || value === tooltipsMinValue
-                    );
+                    // Mega dummy mechanism to catch duplicated values.
+                    let tooltipsMaxValueDisplayed = false;
+                    let tooltipsMinValueDisplayed = false;
+
+                    const displayTooltipsFilter = (value) => {
+                        if (value === tooltipsMaxValue && !tooltipsMaxValueDisplayed) {
+                            tooltipsMaxValueDisplayed = true;
+                            return true;
+                        } else if (value === tooltipsMinValue && !tooltipsMinValueDisplayed) {
+                            tooltipsMinValueDisplayed = true;
+                            return true;
+                        }
+
+                        return false;
+                    };
 
                     chart.getDatasetMeta(i).data.forEach(function (sector, j) {
                         const toolTipValue = dataset.data[j];

--- a/src/js/chart.js
+++ b/src/js/chart.js
@@ -138,28 +138,20 @@ window.App.Chart.prototype.alwaysVisibleTooltipsPlugin = function() {
                 chart.pluginTooltips = [];
                 chart.config.data.datasets.forEach(function (dataset, i) {
                     /**
-                     * If too many tooltips appear - the chart becomes unreadable,
-                     * therefore - filter out the tooltips.
+                     * Display only the tooltips with the min and the max values.
+                     * Filter out all the rest.
                      */
-                    const tooltipsLength = chart.getDatasetMeta(i).data.length;
-                    const displayTooltipsFilter = (i) => {
-                        if (tooltipsLength <= 5) {
-                            return i % 3 === 0;
-                        } else if (tooltipsLength <= 7) {
-                            return i % 3 === 0;
-                        } else if (tooltipsLength <= 12) {
-                            return i % 4 === 0 || i+1 === tooltipsLength;
-                        } else if (tooltipsLength <= 24) {
-                            return i % 8 === 0 || i+1 === tooltipsLength;
-                        } else if (tooltipsLength <= 31) {
-                            return i % 10 === 0 || i+1 === tooltipsLength;
-                        }
+                    const tooltipsMaxValue = Math.max(...dataset.data);
+                    const tooltipsMinValue = Math.min(...dataset.data);
 
-                        return (i) % 24 === 0 || i+1 === tooltipsLength;
-                    };
+                    const displayTooltipsFilter = (value) => (
+                        value === tooltipsMaxValue || value === tooltipsMinValue
+                    );
 
                     chart.getDatasetMeta(i).data.forEach(function (sector, j) {
-                        if (displayTooltipsFilter(j)) {
+                        const toolTipValue = dataset.data[j];
+
+                        if (displayTooltipsFilter(toolTipValue)) {
                             chart.pluginTooltips.push(new Chart.Tooltip({
                                 _chart: chart.chart,
                                 _chartInstance: chart,


### PR DESCRIPTION
Develop an artificial intelligence that determines which are the min and the max price per period and display tooltip only to them.

I'm just kidding. Since I finally figured it out how to get each tooltip value within the loop, it's just a couple of if statements here and there. No more displaying tooltips randomly (based on their index)! 🎉 

<img width="738" alt="screen shot 2018-01-16 at 23 19 45" src="https://user-images.githubusercontent.com/2548061/35012817-c789acc8-fb13-11e7-8236-bfc7563779df.png">
