### PR TITLE
Refactor / Use safer DOM manipulation methods than `.innerHTML`

### DIFF
--- a/src/js/bitcoin.js
+++ b/src/js/bitcoin.js
@@ -195,37 +195,57 @@ window.App.Bitcoin = {
             case this.PERIODS.ONE_HOUR:
             case this.PERIODS.ONE_YEAR:
             case this.PERIODS.ALL: {
-                this.$change.innerHTML = '';
+                this.$change.textContent = '';
                 return;
             }
         }
 
         const getSignedPercentage = (_number) => {
-            const isChangePisitive = _number >= 0;
+            const isChangePositive = _number >= 0;
             const isChangeZero = _number === 0;
 
-            return isChangePisitive && !isChangeZero ? `+${_number}%` : `${_number}%`;
+            return isChangePositive && !isChangeZero ? `+${_number}%` : `${_number}%`;
         };
         const getVisualClass = (_number) => {
-            const isChangePisitive = _number >= 0;
+            const isChangePositive = _number >= 0;
             const isChangeZero = _number === 0;
 
-            return isChangeZero ? '' : isChangePisitive ? 'positive' : 'negative';
+            return isChangeZero ? '' : isChangePositive ? 'positive' : 'negative';
         };
 
-        this.$change.innerHTML = ` (<span class="${getVisualClass(changePercent)}">${getSignedPercentage(changePercent)}</span>
-        ${periodLabel})`;
+        // Clear existing content
+        this.$change.textContent = '';
+
+        // Create and append new content safely
+        const changeElement = document.createElement('span');
+        changeElement.className = getVisualClass(changePercent);
+        changeElement.textContent = getSignedPercentage(changePercent);
+
+        this.$change.appendChild(document.createTextNode(' ('));
+        this.$change.appendChild(changeElement);
+        this.$change.appendChild(document.createTextNode(` ${periodLabel})`));
     },
 
     $lastUpdated: document.querySelector('#last-updated'),
     setLastUpdated() {
         this.repositories['NOW'].getDataUpToDateStatus().then((info) => {
             const prettyLastUpdatedTime = dayjs(info.lastFetched).fromNow();
-            this.$lastUpdated.innerHTML =
+
+            // Clear existing content
+            this.$lastUpdated.textContent = '';
+
+            const lastUpdatedSpan = document.createElement('span');
+            lastUpdatedSpan.className =
+                this.isLocalChartDataOld || this.isLocalNowDataOld ? 'negative' : 'positive';
+            lastUpdatedSpan.textContent = prettyLastUpdatedTime;
+
+            const failureMessage =
                 this.isLocalChartDataOld || this.isLocalNowDataOld
-                    ? `<span class="negative">${prettyLastUpdatedTime}</span>.
-          Data request <span class="negative">failed</span>. Refresh the page to try again.`
-                    : `<span class="positive">${prettyLastUpdatedTime}</span>.`;
+                    ? '. Data request failed. Refresh the page to try again.'
+                    : '.';
+
+            this.$lastUpdated.appendChild(lastUpdatedSpan);
+            this.$lastUpdated.appendChild(document.createTextNode(failureMessage));
 
             this.$lastUpdated.setAttribute('data-tooltip', dayjs(info.lastFetched).calendar());
         });


### PR DESCRIPTION
As per the Mozilla Firefox rejection reason, migrate to safer DOM manipulation alternatives to the `.innerHTML` previously used.