### PR TITLE
Config / Gecko ID

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Replace the New Tab page with Bitcoin price chart",
   "version": "1.1.0",
   "browser_specific_settings": {
-    "gecko": { "id": "904ad0ba-0f9e-4b2d-a868-a467138ba9df" }
+    "gecko": { "id": "{904ad0ba-0f9e-4b2d-a868-a467138ba9df}" }
   },
   "icons": {
     "16": "icons/icon16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Replace the New Tab page with Bitcoin price chart",
   "version": "1.1.0",
   "browser_specific_settings": {
-    "gecko": { "id": "crypto-tab.com" }
+    "gecko": { "id": "extension@crypto-tab.com" }
   },
   "icons": {
     "16": "icons/icon16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,9 @@
   "name": "Crypto Tab",
   "description": "Replace the New Tab page with Bitcoin price chart",
   "version": "1.1.0",
+  "browser_specific_settings": {
+    "gecko": { "id": "crypto-tab.com" }
+  },
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Replace the New Tab page with Bitcoin price chart",
   "version": "1.1.0",
   "browser_specific_settings": {
-    "gecko": { "id": "extension@crypto-tab.com" }
+    "gecko": { "id": "904ad0ba-0f9e-4b2d-a868-a467138ba9df" }
   },
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
In addition to https://github.com/superKalo/crypto-tab/pull/40, Firefox requires us to include the extension ID that should match the ID of the add-on on AMO.