### PR TITLE
Config / Different extension builds for gecko and webkit + service worker fallback for gecko

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,24 @@ To install the project, first make sure you have NodeJS and NPM installed. Prefe
 
 1. To build the extension distribution files, run:
     ```bash
-    npm run build:extension
+    npm run build:extension:webkit
+    ```
+
+    or
+
+    ```bash
+    npm run build:extension:gecko
     ```
 
 1. To build the extension distribution files and re-build (watch) in case of changes, run:
     ```bash
-    npm run build:extension:watch
+    npm run build:extension:watch:webkit
+    ```
+
+    or
+
+    ```bash
+    npm run build:extension:watch:gecko
     ```
 
 1. To build the website distribution files, run:
@@ -38,7 +50,13 @@ To install the project, first make sure you have NodeJS and NPM installed. Prefe
 
 1. To build the website distribution files and re-build (watch) in case of changes, run:
     ```bash
-    npm run build:extension:watch
+    npm run build:extension:watch:webkit
+    ```
+
+    or
+
+    ```bash
+    npm run build:extension:watch:gecko
     ```
 
 Finally, load the extension:
@@ -46,11 +64,11 @@ Finally, load the extension:
 - In Chrome:
     - Navigate to chrome://extensions
     - Select "Developer Mode" and then click "Load unpacked extension..."
-    - From the file browser, choose the `dist/extension/` directory
+    - From the file browser, choose the `dist/extension-webkit/` directory
 
 - In Firefox:
     - Navigate to `about:debugging`
-    - Click "Load Temporary Add-on" and from the file browser, choose the `manifest.json` file in the `dist/extension/` directory
+    - Click "Load Temporary Add-on" and from the file browser, choose the `manifest.json` file in the `dist/extension-gecko/` directory
 
 # 🚔 License
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "name": "crypto-tab",
   "version": "1.1.0",
   "scripts": {
-    "build:extension": "ENV='extension' gulp build",
-    "build:extension:watch": "ENV='extension' gulp build:watch",
+    "build:extension:webkit": "ENV='extension-webkit' gulp build",
+    "build:extension:gecko": "ENV='extension-gecko' gulp build",
+    "build:extension:watch:webkit": "ENV='extension-webkit' gulp build:watch",
+    "build:extension:watch:gecko": "ENV='extension-gecko' gulp build:watch",
     "build:website": "ENV='website' gulp build",
     "build:website:watch": "ENV='website' gulp build:watch"
   },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,5 @@
     "https://bitcoin-price-api.devlabs-projects.info/**/*",
     "https://api.crypto-tab.com/**/*"
   ],
-  "background": {
-    "service_worker": "js/background.js"
-  }
+  "background": @@background
 }


### PR DESCRIPTION
After https://github.com/superKalo/crypto-tab/pull/45 , the Firefox (gecko) extension builds broke, because Firefox doesn't support service workers in manifest v3. They have a concept of background scripts, that in our use-case serve well as a fallback.

Had to introduce extension environment-specific builds though (webkit and gecko).